### PR TITLE
🛡️ Sentinel: Fix Argument Injection in Updater

### DIFF
--- a/Services/UpdateDownloader.cs
+++ b/Services/UpdateDownloader.cs
@@ -430,12 +430,19 @@ namespace geetRPCS.Services
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = updaterPath,
-                    Arguments = $"--source \"{sourcePath}\" --target \"{targetPath}\" --exe \"{exeName}\"",
-                    UseShellExecute = true,
+                    UseShellExecute = false,
                     CreateNoWindow = false
                 };
 
-                Log($"Launching updater: {startInfo.FileName} {startInfo.Arguments}", "INFO");
+                // Use ArgumentList to prevent argument injection
+                startInfo.ArgumentList.Add("--source");
+                startInfo.ArgumentList.Add(sourcePath);
+                startInfo.ArgumentList.Add("--target");
+                startInfo.ArgumentList.Add(targetPath);
+                startInfo.ArgumentList.Add("--exe");
+                startInfo.ArgumentList.Add(exeName);
+
+                Log($"Launching updater: {startInfo.FileName} (args hidden)", "INFO");
                 Process.Start(startInfo);
                 return true;
             }


### PR DESCRIPTION
🛡️ Sentinel Report: Argument Injection Fix

**Vulnerability:**
The update downloader constructed command-line arguments using string interpolation:
`Arguments = $"--source \"{sourcePath}\" --target \"{targetPath}\" ..."`

On Windows, `AppDomain.CurrentDomain.BaseDirectory` often returns a path ending with a backslash (e.g., `C:\App\`). When quoted (`"C:\App\"`), the backslash escapes the closing quote, causing the argument parser to treat the subsequent arguments as part of the path, effectively merging arguments and potentially allowing injection if an attacker can influence the path or folder name.

**Fix:**
I updated `UpdateDownloader.LaunchUpdater` to use `ProcessStartInfo.ArgumentList`. This API handles argument escaping safely and automatically, preventing this class of injection vulnerabilities.

**Verification:**
- Verified that the project builds successfully with the new API usage.
- Verified that `System.Diagnostics.Process` in .NET 8 supports `ArgumentList`.
- Reverted unrelated changes to zip extraction to keep the PR focused and minimal.

---
*PR created automatically by Jules for task [11995133156264853744](https://jules.google.com/task/11995133156264853744) started by @makcrtve*