### PR TITLE
🛡️ Sentinel: Fix argument injection in Updater

### DIFF
--- a/Services/UpdateDownloader.cs
+++ b/Services/UpdateDownloader.cs
@@ -430,12 +430,17 @@ namespace geetRPCS.Services
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = updaterPath,
-                    Arguments = $"--source \"{sourcePath}\" --target \"{targetPath}\" --exe \"{exeName}\"",
-                    UseShellExecute = true,
+                    UseShellExecute = false,
                     CreateNoWindow = false
                 };
+                startInfo.ArgumentList.Add("--source");
+                startInfo.ArgumentList.Add(sourcePath);
+                startInfo.ArgumentList.Add("--target");
+                startInfo.ArgumentList.Add(targetPath);
+                startInfo.ArgumentList.Add("--exe");
+                startInfo.ArgumentList.Add(exeName);
 
-                Log($"Launching updater: {startInfo.FileName} {startInfo.Arguments}", "INFO");
+                Log($"Launching updater: {startInfo.FileName} [Arguments hidden]", "INFO");
                 Process.Start(startInfo);
                 return true;
             }

--- a/UpdaterHelper/Program.cs
+++ b/UpdaterHelper/Program.cs
@@ -190,12 +190,13 @@ namespace geetRPCS.Updater
             // Method 1: Via explorer.exe
             try
             {
-                Process.Start(new ProcessStartInfo
+                var psi = new ProcessStartInfo
                 {
                     FileName = "explorer.exe",
-                    Arguments = "\"" + path + "\"",
                     UseShellExecute = false
-                });
+                };
+                psi.ArgumentList.Add(path);
+                Process.Start(psi);
                 return;
             }
             catch { }


### PR DESCRIPTION
This PR fixes a critical security vulnerability where command arguments were being constructed using string concatenation. This is susceptible to argument injection, especially when paths contain trailing backslashes (common with `AppDomain.CurrentDomain.BaseDirectory` on Windows) or other special characters.

Changes:
- Modified `LaunchUpdater` in `Services/UpdateDownloader.cs` to use `ArgumentList`.
- Modified `LaunchViaExplorer` in `UpdaterHelper/Program.cs` to use `ArgumentList`.
- Set `UseShellExecute = false` to enable `ArgumentList` usage and bypass shell parsing.
- Added a Sentinel journal entry documenting the vulnerability.

This improves the robustness and security of the update process.

---
*PR created automatically by Jules for task [8142287841869637313](https://jules.google.com/task/8142287841869637313) started by @makcrtve*