### PR TITLE
🛡️ Sentinel: [HIGH] Fix Argument Injection in Updater

### DIFF
--- a/Services/UpdateDownloader.cs
+++ b/Services/UpdateDownloader.cs
@@ -430,12 +430,17 @@ namespace geetRPCS.Services
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = updaterPath,
-                    Arguments = $"--source \"{sourcePath}\" --target \"{targetPath}\" --exe \"{exeName}\"",
-                    UseShellExecute = true,
+                    UseShellExecute = false,
                     CreateNoWindow = false
                 };
+                startInfo.ArgumentList.Add("--source");
+                startInfo.ArgumentList.Add(sourcePath);
+                startInfo.ArgumentList.Add("--target");
+                startInfo.ArgumentList.Add(targetPath);
+                startInfo.ArgumentList.Add("--exe");
+                startInfo.ArgumentList.Add(exeName);
 
-                Log($"Launching updater: {startInfo.FileName} {startInfo.Arguments}", "INFO");
+                Log($"Launching updater: {startInfo.FileName} {string.Join(" ", startInfo.ArgumentList)}", "INFO");
                 Process.Start(startInfo);
                 return true;
             }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Argument Injection in Updater

**Vulnerability:**
Argument Injection via `AppDomain.CurrentDomain.BaseDirectory` which contains a trailing backslash on Windows. When used in string concatenation for arguments (e.g., `"--target \"{path}\" --exe ..."`), the trailing backslash escapes the closing quote, causing the subsequent arguments to be swallowed or allowing injection of malicious arguments.

**Fix:**
- Modified `Services/UpdateDownloader.cs` to use `ProcessStartInfo.ArgumentList` which handles argument escaping safely and automatically.
- Disabled `UseShellExecute` as it is required for `ArgumentList`.

**Verification:**
- Verified that the project builds successfully (`dotnet build -p:EnableWindowsTargeting=true`).
- Code review confirmed the fix is correct and follows .NET best practices.

---
*PR created automatically by Jules for task [15604225502534350603](https://jules.google.com/task/15604225502534350603) started by @makcrtve*