### PR TITLE
🛡️ Sentinel: Fix Argument Injection in Updater Launch

### DIFF
--- a/Services/UpdateDownloader.cs
+++ b/Services/UpdateDownloader.cs
@@ -430,12 +430,17 @@ namespace geetRPCS.Services
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = updaterPath,
-                    Arguments = $"--source \"{sourcePath}\" --target \"{targetPath}\" --exe \"{exeName}\"",
-                    UseShellExecute = true,
+                    UseShellExecute = false,
                     CreateNoWindow = false
                 };
+                startInfo.ArgumentList.Add("--source");
+                startInfo.ArgumentList.Add(sourcePath);
+                startInfo.ArgumentList.Add("--target");
+                startInfo.ArgumentList.Add(targetPath);
+                startInfo.ArgumentList.Add("--exe");
+                startInfo.ArgumentList.Add(exeName);
 
-                Log($"Launching updater: {startInfo.FileName} {startInfo.Arguments}", "INFO");
+                Log($"Launching updater: {startInfo.FileName} {string.Join(" ", startInfo.ArgumentList)}", "INFO");
                 Process.Start(startInfo);
                 return true;
             }


### PR DESCRIPTION
**Vulnerability:**
The `LaunchUpdater` method constructed command-line arguments using string concatenation (`$"--source \"{sourcePath}\" ..."`). If any path variable contained malicious characters or if the BaseDirectory (on Windows) ended with a backslash, it could escape the closing quote and allow argument injection.

**Fix:**
- Refactored `LaunchUpdater` to use `ProcessStartInfo.ArgumentList`.
- `ArgumentList` handles escaping and quoting automatically and securely.
- Disabled `UseShellExecute` as required for `ArgumentList`.

**Verification:**
- Verified code changes and compilation.
- Verified that `UpdaterHelper` accepts the arguments in the format generated by `ArgumentList`.
- Added journal entry in `.jules/sentinel.md` documenting the learning.

---
*PR created automatically by Jules for task [9547097776120370012](https://jules.google.com/task/9547097776120370012) started by @makcrtve*