### PR TITLE
🛡️ Sentinel: Fix argument injection in process launching

### DIFF
--- a/Services/UpdateDownloader.cs
+++ b/Services/UpdateDownloader.cs
@@ -430,12 +430,17 @@ namespace geetRPCS.Services
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = updaterPath,
-                    Arguments = $"--source \"{sourcePath}\" --target \"{targetPath}\" --exe \"{exeName}\"",
-                    UseShellExecute = true,
+                    UseShellExecute = false,
                     CreateNoWindow = false
                 };
+                startInfo.ArgumentList.Add("--source");
+                startInfo.ArgumentList.Add(sourcePath);
+                startInfo.ArgumentList.Add("--target");
+                startInfo.ArgumentList.Add(targetPath);
+                startInfo.ArgumentList.Add("--exe");
+                startInfo.ArgumentList.Add(exeName);
 
-                Log($"Launching updater: {startInfo.FileName} {startInfo.Arguments}", "INFO");
+                Log($"Launching updater: {startInfo.FileName} {string.Join(" ", startInfo.ArgumentList)}", "INFO");
                 Process.Start(startInfo);
                 return true;
             }

--- a/UpdaterHelper/Program.cs
+++ b/UpdaterHelper/Program.cs
@@ -190,12 +190,13 @@ namespace geetRPCS.Updater
             // Method 1: Via explorer.exe
             try
             {
-                Process.Start(new ProcessStartInfo
+                var psi = new ProcessStartInfo
                 {
                     FileName = "explorer.exe",
-                    Arguments = "\"" + path + "\"",
                     UseShellExecute = false
-                });
+                };
+                psi.ArgumentList.Add(path);
+                Process.Start(psi);
                 return;
             }
             catch { }


### PR DESCRIPTION
**Vulnerability:** Argument Injection in `Process.Start` calls.
**Impact:** Potential for arbitrary command execution or unexpected behavior if file paths contain malicious characters (e.g. quotes).
**Fix:** Switched to using `ProcessStartInfo.ArgumentList` which safely handles argument escaping. This required setting `UseShellExecute = false`.
**Verification:** Verified compilation of both `UpdaterHelper` and `geetRPCS`. Manual verification of code changes confirms correct usage of `ArgumentList`.

---
*PR created automatically by Jules for task [15040058849597643786](https://jules.google.com/task/15040058849597643786) started by @makcrtve*