### PR TITLE
🛡️ Sentinel: Fix argument injection in Process.Start

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -928,7 +928,12 @@ class Program : ApplicationContext
             Log($"Failed to open {fileName}: {ex.Message}");
             var result = MessageBox.Show(LanguageManager.Current.DialogOpenWithNotepad, LanguageManager.Current.AppName,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-            if (result == DialogResult.Yes) System.Diagnostics.Process.Start("notepad.exe", filePath);
+            if (result == DialogResult.Yes)
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo("notepad.exe") { UseShellExecute = false };
+                psi.ArgumentList.Add(filePath);
+                System.Diagnostics.Process.Start(psi);
+            }
         }
     }
     private void UpdateTrayMenu()

--- a/Services/UpdateDownloader.cs
+++ b/Services/UpdateDownloader.cs
@@ -430,12 +430,18 @@ namespace geetRPCS.Services
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = updaterPath,
-                    Arguments = $"--source \"{sourcePath}\" --target \"{targetPath}\" --exe \"{exeName}\"",
-                    UseShellExecute = true,
+                    UseShellExecute = false,
                     CreateNoWindow = false
                 };
 
-                Log($"Launching updater: {startInfo.FileName} {startInfo.Arguments}", "INFO");
+                startInfo.ArgumentList.Add("--source");
+                startInfo.ArgumentList.Add(sourcePath);
+                startInfo.ArgumentList.Add("--target");
+                startInfo.ArgumentList.Add(targetPath);
+                startInfo.ArgumentList.Add("--exe");
+                startInfo.ArgumentList.Add(exeName);
+
+                Log($"Launching updater: {startInfo.FileName} --source \"{sourcePath}\" --target \"{targetPath}\" --exe \"{exeName}\"", "INFO");
                 Process.Start(startInfo);
                 return true;
             }


### PR DESCRIPTION
This PR fixes a potential argument injection vulnerability by replacing string concatenation for process arguments with the safer `ProcessStartInfo.ArgumentList` API. This ensures that arguments are properly escaped and handled by the .NET runtime, preventing malicious input from altering the command execution.

Changes:
- Modified `Services/UpdateDownloader.cs`: Used `ArgumentList` for launching the updater.
- Modified `Program.cs`: Used `ArgumentList` for launching Notepad fallback.
- Added security journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11544268974030301048](https://jules.google.com/task/11544268974030301048) started by @makcrtve*